### PR TITLE
Set up deployment with Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Hubot Control
+
+FROM ubuntu:13.10
+
+# install dependencies
+RUN apt-get update && apt-get install -y git-core curl zlib1g-dev build-essential libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev libcurl4-openssl-dev python-software-properties libpq-dev nodejs nodejs-legacy npm
+RUN npm install -g coffee-script
+RUN npm install -g hubot
+
+# install rbenv
+RUN git clone https://github.com/sstephenson/rbenv.git /usr/local/rbenv
+RUN git clone https://github.com/sstephenson/ruby-build.git /usr/local/rbenv/plugins/ruby-build
+RUN echo '# rbenv setup' > /etc/profile.d/rbenv.sh
+RUN echo 'export RBENV_ROOT=/usr/local/rbenv' >> /etc/profile.d/rbenv.sh
+RUN echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >> /etc/profile.d/rbenv.sh
+RUN echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh
+RUN chmod +x /etc/profile.d/rbenv.sh
+ENV RBENV_ROOT /usr/local/rbenv
+ENV PATH /usr/local/rbenv/shims:/usr/local/rbenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# install ruby 2.0
+RUN rbenv install 2.0.0-p451
+RUN rbenv global 2.0.0-p451
+
+# skip installing documentation
+RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+
+RUN gem install bundler && rbenv rehash
+
+ADD . /usr/src/hubot-control
+WORKDIR /usr/src/hubot-control
+
+RUN bundle install --system && rbenv rehash
+
+RUN RAILS_ENV=production bundle exec rake assets:precompile
+
+EXPOSE 3000
+CMD ["bundle", "exec", "unicorn", "-p", "3000", "-c", "./config/unicorn.rb", "-E", "production"]

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,3 +17,13 @@ test:
   database: db/test.sqlite3
   pool: 5
   timeout: 5000
+
+production:
+  adapter: <%= ENV["RAILS_DB_ADAPTER"] || "postgresql" %>
+  encoding: <%= ENV["RAILS_DB_ENCODING"] || "unicode" %>
+  database: <%= ENV["RAILS_DB_DATABASE"] || "hubot_control" %>
+  pool: <%= ENV["RAILS_DB_POOL"] || "5" %>
+  username: <%= ENV["RAILS_DB_USERNAME"] %>
+  password: <%= ENV["RAILS_DB_PASSWORD"] %>
+  host: <%= ENV["RAILS_DB_HOST"] || ENV["DB_PORT_5432_TCP_ADDR"] %>
+  port: <%= ENV["RAILS_DB_PORT"] || ENV["$DB_PORT_5432_TCP_PORT"] %>


### PR DESCRIPTION
This pull request sets up Hubot Control for deployment with Docker.

The following changes are made
- A Dockerfile is created
- Instructions for running with Docker are added to the README
- Add defaults to `production` in `config/database.yml` and load settings from environment variables.

I'm currently running this in a production environment on CoreOS and it works well. The only potential "issue" is that the process is run as the root user, which is shown as a warning in the Hubot Control interface, but running processes as the root user in Docker containers is standard practice and creating and managing hubots works fine.
