### PR TITLE
hubot --create deprecated

### DIFF
--- a/app/controllers/status_controller.rb
+++ b/app/controllers/status_controller.rb
@@ -5,6 +5,7 @@ class StatusController < ApplicationController
     @npm               = Status.npm
     @coffee            = Status.coffee
     @hubot             = Status.hubot
+    @yo                = Status.yo
     @hubots_dir        = Hubot.base_dir
     @scripts_dir       = Script.base_dir
     @hubots_dir_perms  = Status.hubot_dir_writable?

--- a/app/models/hubot.rb
+++ b/app/models/hubot.rb
@@ -157,7 +157,7 @@ class Hubot < ActiveRecord::Base
 
     def install
       self.location = File.join(Hubot.base_dir, title.parameterize)
-      log Shell.run("hubot --create #{self.location}")
+      log Shell.run("cd #{self.location} && yo hubot --name='#{name}' --adapter=#{adapter} --defaults")
       log Shell.run("cd #{self.location} && bin/hubot -v")
     end
 

--- a/app/models/hubot.rb
+++ b/app/models/hubot.rb
@@ -157,6 +157,7 @@ class Hubot < ActiveRecord::Base
 
     def install
       self.location = File.join(Hubot.base_dir, title.parameterize)
+      log Shell.run("mkdir #{self.location}")
       log Shell.run("cd #{self.location} && yo hubot --name='#{name}' --adapter=#{adapter} --defaults")
       log Shell.run("cd #{self.location} && bin/hubot -v")
     end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -18,6 +18,10 @@ class Status
       @@hubot ||= Shell.run('hubot -v').try(:strip)
     end
 
+    def yo
+      @@yo ||= Shell.run('yo --version').try(:strip)
+    end
+
     def hubot_dir_writable?
       begin
         FileUtils.mkdir_p(Hubot.base_dir)

--- a/app/views/status/show.html.erb
+++ b/app/views/status/show.html.erb
@@ -26,6 +26,11 @@
     <td><%= feedback(@hubot, 'Installed', 'Not Installed') %></td>
   </tr>
   <tr>
+    <td>Yo</td>
+    <td><%= @yo || 'Run <code>npm install -g yo generator-hubot</code> after Hubot, Node, NPM and CoffeeScript are installed'.html_safe %></td>
+    <td><%= feedback(@yo, 'Installed', 'Not Installed') %></td>
+  </tr>
+  <tr>
     <td>System user</td>
     <td><%= @sys_user %></td>
     <td><%= feedback(@not_root, 'OK', "Running hubot-control as root user") %></td>


### PR DESCRIPTION
Swapped out the hubot --create command for yo hubot, which gets hubot-control working again. Still need to add yo and generator-hubot to the status page detection