### PR TITLE
Fix Docker Postgres authentication error

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Prerequisites:
 
 Start a Postgres instance
 
-    docker run --name hubot-control-db -d -e USER="docker" -e DB="hubot_control" -e PASS="docker" paintedfox/postgresql
+    docker run --name hubot-control-db -d -e DB_USER="docker" -e DB="hubot_control" -e PASS="docker" hackedu/postgresql
 
 Create a data-only container to store Hubots
 


### PR DESCRIPTION
#13 was caused by Painted-Fox/docker-postgresql#30 and by the `USER` environment variable being changed to `DB_USER`. I've built my own Postgres image with the changes in Painted-Fox/docker-postgresql#38, pushed it to `hackedu/postgresql`, and changed the README to use that.